### PR TITLE
Corrects Controller inheritance and other goodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # phalcon-json-api-package
 A composer package designed to help you create a JSON:API in Phalcon
 
-What happens when a PHP developer wants to create an api to drive their client-side SPA?  Well you start with [Phalcon](http://phalconphp.com/en/) (A modern super fast framework) loosely follow the [JSON:API](http://jsonapi.org/) and package it up for [Composer](https://getcomposer.org/).  The result is the phalcon-json-api package (herafter referred to as the API) so enjoy.
+What happens when a PHP developer wants to create an api to drive their client-side SPA?  Well you start with [Phalcon](http://phalconphp.com/en/) (A modern, super fast framework), loosely follow the [JSON:API](http://jsonapi.org/) spec, and package it up for [Composer](https://getcomposer.org/).  The result is the phalcon-json-api package (herafter referred to as the API) so enjoy.
 
 # System Requirements
 - Phalcon 2.x
-- SQL persistance layer (ie. MYSQL, MariaDB)  Make sure the database is supported by [Phalcon's Databse Abstation Layer](https://docs.phalconphp.com/en/latest/reference/db.html).
+- SQL persistance layer (ie. MYSQL, MariaDB).  Make sure the database is supported by [Phalcon's Databse Abstraction Layer](https://docs.phalconphp.com/en/2.0.0/reference/db.html).
 - PHP Version 5.5 or greater?
 
 # Release Notes

--- a/src/API/BaseController.php
+++ b/src/API/BaseController.php
@@ -3,6 +3,7 @@ namespace PhalconRest\API;
 
 use Phalcon\DI;
 use Phalcon\DI\Injectable;
+use Phalcon\Mvc\Controller;
 use \PhalconRest\Util\HTTPException;
 
 /**
@@ -14,7 +15,7 @@ use \PhalconRest\Util\HTTPException;
  * Responsible for handling various REST requests
  * Will load the correct model and entity and perform the correct action
  */
-class BaseController extends Injectable
+class BaseController extends Controller
 {
 
     /**
@@ -22,43 +23,37 @@ class BaseController extends Injectable
      *
      * @var \PhalconRest\API\Entity
      */
-    protected $entity = FALSE;
+    protected $entity;
 
     /**
      * Store the default model here
      *
      * @var \PhalconRest\API\BaseModel
      */
-    protected $model = FALSE;
+    protected $model;
 
     /**
-     * the name of the controller
-     * derived from inflection
+     * The name of the controller, derived from inflection
      *
      * @var string
      */
-    public $singularName = null;
+    public $singularName;
 
     /**
-     * plural version of controller name
-     * used for Ember compatible rest returns
+     * Plural version of controller name. Used for Ember-compatible REST returns
      *
      * @var string
      */
-    public $pluralName = null;
+    public $pluralName;
 
     /**
-     * Constructor, calls the parse method for the query string by default.
-     *
-     * @param boolean $parseQueryString
-     *            true Can be set to false if a controller needs to be called
-     *            from a different controller, bypassing the $allowedFields parse
+     * Includes the default Dependency Injector and loads the Entity.
      */
-    public function __construct($parseQueryString = true)
+    public function onConstruct()
     {
         $di = DI::getDefault();
         $this->setDI($di);
-        // initialize entity and set to class property
+        // initialize entity and set to class property (doing the same to the model property)
         $this->getEntity();
     }
 
@@ -97,6 +92,7 @@ class BaseController extends Injectable
      * Load a default entity unless one is already in place
      * return the currently loaded entity
      *
+     * @see $entity
      * @return \PhalconRest\API\Entity
      */
     public function getEntity()

--- a/src/API/SecureController.php
+++ b/src/API/SecureController.php
@@ -10,53 +10,27 @@ use \PhalconRest\Util\HTTPException;
 class SecureController extends BaseController
 {
 
-    public function __construct($parseQueryString = true)
+    public function onConstruct()
     {
+        parent::onConstruct();
         $config = $this->getDI()->get('config');
         $auth = $this->getDI()->get('auth');
 
         switch ($config['security']) {
             case true:
-                $headerToken = $this->request->getHeader("X_AUTHORIZATION");
-                $queryParamToken = $this->getDI()
-                    ->get('request')
-                    ->getQuery("token");
+                $token = $this->getAuthToken();
 
-                $postedParamToken = $this->getDI()
-                    ->get('request')
-                    ->getPost("token");
-
-                // try to read in from header first, otherwise attempt to read in from query param
-                if ($headerToken !== "") {
-                    $token = $headerToken;
-                } elseif (! is_null($queryParamToken)) {
-                    $token = $queryParamToken;
-                } elseif (! is_null($postedParamToken)) {
-                    $token = $postedParamToken;
-                    unset($_POST["token"]);
-                } else {
-                    $token = "";
-                }
-
-                $token = trim(str_ireplace("Token: ", '', $token));
-                if (strlen($token) < 30) {
-                    throw new HTTPException("Bad token supplied", 401, array(
-                        'dev' => 'Supplied Token: ' . $token,
-                        'code' => '0273497957'
-                    ));
-                }
                 // check for a valid session
                 if ($auth->isLoggedIn($token)) {
                     // get the security service object
                     $securityService = $this->getDI()->get('securityService');
                     // run security check
                     $this->securityCheck($securityService);
-                    parent::__construct($parseQueryString);
                 } else {
-                    throw new HTTPException("Unauthorized, please authenticate first.", 401, array(
-                        'dev' => "Must be authenticated to access.",
+                    throw new HTTPException('Unauthorized, please authenticate first.', 401, [
+                        'dev' => 'Must be authenticated to access.',
                         'code' => '30945680384502037'
-                    ));
+                    ]);
                 }
                 break;
 
@@ -65,25 +39,47 @@ class SecureController extends BaseController
                 // todo figure out a way to do this w/o this assumption
                 // notice the specific requirement to a client application
                 if ($auth->isLoggedIn('HACKYHACKERSON')) {
-                    // get the security service object
-                    $securityService = $this->getDI()->get('securityService');
                     // run security check
-                    $this->securityCheck($securityService);
-                    parent::__construct($parseQueryString);
+                    $this->securityCheck($this->getDI()->get('securityService'));
                 } else {
-                    throw new HTTPException("Security False is not loading a valid user.", 401, array(
-                        'dev' => "The authenticator isn't loading a valid user.",
+                    throw new HTTPException('Security False is not loading a valid user.', 401, [
+                        'dev' => 'The authenticator isn\'t loading a valid user.',
                         'code' => '23749873490704'
-                    ));
+                    ]);
                 }
                 break;
 
             default:
-                throw new HTTPException("Bad security value supplied", 500, array(
-                    'code' => '280273409724075'
-                ));
+                throw new HTTPException('Bad security value supplied', 500, ['code' => '280273409724075']);
                 break;
         }
+    }
+
+    /**
+     * Tries to get the Authorization Token in this order:
+     * 1. Header: X-Authorization
+     * 2. GET "token"
+     * 3. POST "token"
+     * @throws HTTPException 401 If token is not found
+     * @return string
+     */
+    protected function getAuthToken()
+    {
+        $token = $this->request->getHeader('X_AUTHORIZATION');
+        if (!$token) {
+            $request = $this->getDI()->get('request');
+            $token = $request->getQuery('token')?: $request->getPost('token');
+        }
+
+        $token = trim(str_ireplace('Token:', '', $token));
+        if (strlen($token) < 30) {
+            throw new HTTPException('Bad token supplied', 401, [
+                'dev' => 'Supplied Token: ' . $token,
+                'code' => '0273497957'
+            ]);
+        }
+
+        return $token;
     }
 
     /**


### PR DESCRIPTION
This is a breaking change, as projects using this package will start breaking if they use `__construct()` in their controllers. Thus, if we are to follow SemVer, this should be released as 2.0 (and docs/wiki should start referencing the JSON:API compliant version as 3.0?).
