### PR TITLE
Moving throwOnSave behavior from Entity to BaseModel

### DIFF
--- a/src/API/BaseModel.php
+++ b/src/API/BaseModel.php
@@ -139,7 +139,7 @@ class BaseModel extends \Phalcon\Mvc\Model
      * @see $throwOnSave
      * @see throwOnNextSave()
      * @see save()
-     * @var bool
+     * @var bool|null
      */
     public $throwOnNextSave = null;
 
@@ -180,7 +180,7 @@ class BaseModel extends \Phalcon\Mvc\Model
             return $this->singularName;
         }
 
-        // todo throw and error here?
+        // todo throw an error here?
         return false;
     }
 
@@ -576,7 +576,7 @@ class BaseModel extends \Phalcon\Mvc\Model
      * @see \Phalcon\Mvc\Model::save()
      * @param null $data
      * @param null $whiteList
-     * @return bool
+     * @return int|false Returns false on failures (if throw behavior is disabled) and the PKID on success calls
      * @throws ValidationException
      */
     public function save($data = null, $whiteList = null)
@@ -602,6 +602,8 @@ class BaseModel extends \Phalcon\Mvc\Model
                     'dev' => 'BaseModel::save() failed'
                 ], $this->getMessages());
             }
+        } else { //it worked! let's return something more useful than a boolean: the ID
+            return $this->getPrimaryKeyValue();
         }
 
         return $result;

--- a/src/API/BaseModel.php
+++ b/src/API/BaseModel.php
@@ -261,7 +261,7 @@ class BaseModel extends \Phalcon\Mvc\Model
     public function getPrimaryKeyValue()
     {
         $key = $this->getPrimaryKeyName();
-        return $this->$key;
+        return isset($this->$key)? $this->$key : null;
     }
 
     /**
@@ -576,7 +576,9 @@ class BaseModel extends \Phalcon\Mvc\Model
      * @see \Phalcon\Mvc\Model::save()
      * @param null $data
      * @param null $whiteList
-     * @return int|false Returns false on failures (if throw behavior is disabled) and the PKID on success calls
+     * @return int|bool Returns false on failures (if throw behavior is disabled) and the PKID on success calls.
+     *                  May return true if the PKID cannot be found (on {@link getPrimaryKeyValue()),
+     *                  but the save worked nonetheless.
      * @throws ValidationException
      */
     public function save($data = null, $whiteList = null)
@@ -597,13 +599,14 @@ class BaseModel extends \Phalcon\Mvc\Model
             }
 
             if ($throw) {
-                throw new ValidationException("Validation Errors Encountered", [
+                throw new ValidationException('Validation Errors Encountered', [
                     'code' => '50986904809',
-                    'dev' => 'BaseModel::save() failed'
+                    'dev' => get_called_class().'::save() failed'
                 ], $this->getMessages());
             }
-        } else { //it worked! let's return something more useful than a boolean: the ID
-            return $this->getPrimaryKeyValue();
+        } else { //it worked! let's return something more useful than a boolean: the ID, if possible
+            //an ID might not be found if there's something odd with the model's PK (hidden, for instance)
+            return $this->getPrimaryKeyValue()?: true;
         }
 
         return $result;

--- a/src/API/Entity.php
+++ b/src/API/Entity.php
@@ -1300,7 +1300,7 @@ class Entity extends Injectable
             // }
         }
 
-        $result = $this->simpleSave($primaryModel);
+        $result = $primaryModel->save();
 
         // if still blank, pull from recently created $result
         if (is_null($id)) {
@@ -1393,16 +1393,15 @@ class Entity extends Injectable
     }
 
     /**
-     * save a model and collect any error messages that may be returned
-     * return the model PKID whether insert or update
-     *
+     * Simple alias for {@link BaseModel::save()}.
+     * Used to do more stuff that now happens inside the model. Replace with <code>$model->save()</code>.
+     * @deprecated
      * @param BaseModel $model
      * @throws ValidationException
-     * @return int
+     * @return int|false
      */
     function simpleSave($model)
     {
-        $model->save(); //can throw an exception if a validation issue happens
-        return $model->getPrimaryKeyValue();
+        return $model->save();
     }
 }

--- a/src/API/Entity.php
+++ b/src/API/Entity.php
@@ -1395,14 +1395,7 @@ class Entity extends Injectable
      */
     function simpleSave($model)
     {
-        $result = $model->save();
-        // if the save failed, gather errors and return a validation failure
-        if ($result == false) {
-            throw new ValidationException("Validation Errors Encountered", array(
-                'code' => '7894181864684',
-                'dev' => 'entity->simpleSave failed to save model'
-            ), $model->getMessages());
-        }
+        $model->save(); //can throw an exception if a validation issue happens
         return $model->getPrimaryKeyValue();
     }
 }


### PR DESCRIPTION
This makes all models throw exceptions when their save() calls fail.

However, while I feel this throwing behavior should be on by default, that's also a breaking change.
The behavior is easily overridden by adding a config line, but that doesn't make it "less breaking change":

``` php
BaseModel::$throwOnSave = false; //this can be set on config/services.php, or anywhere in controllers
$myModel->throwOnNextSave = false; //used only once, valid for the next save() call
$myModel->throwOnNextSave(false)->save(); //same as above, easier to read
```

We could:
1. release it defaulting to true as 2.1 and breaking SemVer a bit;
2. release as 3.0 and just pretend 2.0 never happened but keeping SemVer valid;
3. leave it as false for BC, and use a config line to enable that on a per-project basis.

How do you feel about that feature, should it be on or off by default?
