### PR TITLE
mungeData is not mandatory, and other small improvements

### DIFF
--- a/src/API/BaseController.php
+++ b/src/API/BaseController.php
@@ -207,10 +207,10 @@ class BaseController extends Controller
         $post = $request->getJson($this->getControllerName('singular'), $this->model);
 
         if (!$post) {
-            throw new HTTPException("There was an error adding new record.  Missing POST data.", 400, array(
-                'dev' => "Invalid data posted to the server",
-                'code' => '568136818916816'
-            ));
+            throw new HTTPException('There was an error adding new record.  Missing POST data.', 400, [
+                'dev' => 'Invalid data posted to the server',
+                'code' => '568136818916816555'
+            ]);
         }
 
         // filter out any block columns from the posted data
@@ -229,10 +229,10 @@ class BaseController extends Controller
 
         if ($result->countResults() == 0) {
             // This is bad. Throw a 500. Responses should always be objects.
-            throw new HTTPException("There was an error retrieving the newly created record.", 500, array(
+            throw new HTTPException('There was an error retrieving the newly created record.', 500, [
                 'dev' => 'The resource you requested is not available after it was just created',
                 'code' => '1238510381861'
-            ));
+            ]);
         } else {
             return $result;
         }
@@ -266,7 +266,7 @@ class BaseController extends Controller
 
         if (!$put) {
             throw new HTTPException('There was an error updating an existing record.', 500, [
-                'dev' => "Invalid data posted to the server",
+                'dev' => 'Invalid data posted to the server',
                 'code' => '568136818916816'
             ]);
         }

--- a/src/API/Entity.php
+++ b/src/API/Entity.php
@@ -1144,8 +1144,6 @@ class Entity extends Injectable
      */
     public function save($formData, $id = null)
     {
-        // $inflector = new Inflector();
-
         // check if inserting a new record and account for any parent records
         if (is_null($id)) {
             $this->saveMode = 'insert';
@@ -1177,7 +1175,8 @@ class Entity extends Injectable
             $this->primaryKeyValue = $id;
 
             // need parent logic here
-            $primaryModel = $this->loadParentModel(($this->model)::findFirst($id), $formData);
+            $this->model = ($this->model)::findFirst($id);
+            $primaryModel = $this->loadParentModel($this->model, $formData);
 
             // // TODO this only works with 1 parent so far....
             // $parentModelName = $model::$parentModel;
@@ -1190,7 +1189,7 @@ class Entity extends Injectable
             // }
         }
 
-        // no need to pass in formdata since it was already loaded in $this->loadParentModel
+        // no need to pass in formData since it was already loaded in $this->loadParentModel
         $result = $primaryModel->save();
 
         // if still blank, pull from recently created $result
@@ -1199,10 +1198,10 @@ class Entity extends Injectable
         }
 
         // post save hook that is called before relationships have been saved
-        $this->afterSave($this->model, $id);
+        $this->afterSave($formData, $id);
 
         // post save hook that is called after all relations have been saved as well
-        $this->afterSaveRelations($this->model, $id);
+        $this->afterSaveRelations($formData, $id);
 
         $this->saveMode = null; // revert since save is finished
         return $this->primaryKeyValue;

--- a/src/Request/Adapters/ActiveModel.php
+++ b/src/Request/Adapters/ActiveModel.php
@@ -20,10 +20,10 @@ class ActiveModel extends Request
      *
      * @param $name
      * @param BaseModel $model
-     * @return \stdClass|bool  the requested JSON property otherwise false
+     * @return \stdClass the requested JSON property otherwise null
      * @throws HTTPException
      */
-    public function getJson($name, \PhalconRest\API\BaseModel $model)
+    public function getJson($name, BaseModel $model)
     {
         // normalize name to all lower case
         $inflector = new Inflector();
@@ -31,44 +31,28 @@ class ActiveModel extends Request
 
         // $raw = $this->getRawBody();
         $json = $this->getJsonRawBody();
-        $request = null;
         if (is_object($json)) {
-            if ($name != null) {
+            if ($name) {
                 if (isset($json->$name)) {
                     $request = $json->$name;
                 } else {
                     // expected name not found
-                    throw new HTTPException("Could not find expected json data.", 500, array(
+                    throw new HTTPException('Could not find expected json data.', 500, [
                         'dev' => json_encode($json),
                         'code' => '4684646464684'
-                    ));
-                    return false;
+                    ]);
                 }
             } else {
                 // return the entire result set
                 $request = $json;
-                unset($json);
             }
         } else {
             // invalid json detected
-            return false;
+            return null;
         }
+
         // give convert a chance to run
-        $request = $this->convertCase($request);
-        return $this->mungeData($request, $model);
-    }
-
-
-    /**
-     * not much to do here in activemodel
-     *
-     * @param $post
-     * @param BaseModel $model
-     * @return mixed
-     */
-    public function mungeData($post, BaseModel $model)
-    {
-        return $post;
+        return $this->convertCase($request);
     }
 
 }

--- a/src/Request/Adapters/JsonApi.php
+++ b/src/Request/Adapters/JsonApi.php
@@ -19,9 +19,9 @@ class JsonApi extends Request
      *
      * @param string $name
      * @param BaseModel $model
-     * @return \stdClass requested JSON property otherwise false
+     * @return \stdClass requested JSON property otherwise null
      */
-    public function getJson($name, \PhalconRest\API\BaseModel $model)
+    public function getJson($name, BaseModel $model)
     {
         // $raw = $this->getRawBody();
         $json = $this->getJsonRawBody();
@@ -32,7 +32,7 @@ class JsonApi extends Request
             $request = $json->data;
         } else {
             // invalid json detected
-            return false;
+            return null; //todo: throw an error instead?
         }
         // give convert a chance to run
         $request = $this->convertCase($request);
@@ -49,13 +49,13 @@ class JsonApi extends Request
      * @throws HTTPException
      */
 
-    public function mungeData($post, BaseModel $model)
+    public function mungeData($post, BaseModel $model):\stdClass
     {
         // munge a bit so it works for internal data handling
         if (!isset($post->attributes)) {
             // error here, all posts require an attributes tag
-            throw new HTTPException("The API received a malformed API request", 400, [
-                'dev' => 'Bad or incomplete attributes property submitted to the api',
+            throw new HTTPException('The API received a malformed request', 400, [
+                'dev' => 'Bad or incomplete attributes property submitted to the API',
                 'code' => '894168146168168168161'
             ]);
         } else {
@@ -88,13 +88,14 @@ class JsonApi extends Request
                         break;
 
                     case PhalconRelation::HAS_MANY:
-                        // pull plural?
+                        //TODO: pull plural?
                         break;
                     default:
                         break;
                 }
             }
         }
+
         return $data;
     }
 

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -21,31 +21,17 @@ abstract class Request extends \Phalcon\Http\Request
      */
     public $defaultCaseFormat = false;
 
-
-    /**
-     * function that should be implemented to perform additional processing that "fixes" data
-     *
-     * @param $post
-     * * @param BaseModel $model
-     * @return mixed
-     */
-    abstract function mungeData($post, BaseModel $model);
-
     /**
      * @param $name
      * @param BaseModel $model
-     * @return mixed
+     * @return \stdClass
      */
-    abstract function getJson($name, \PhalconRest\API\BaseModel $model);
-
+    abstract function getJson($name, BaseModel $model);
 
     /**
      * extend to hook up possible case conversion
      *
-     * @param string $name
-     * @param string $filters
-     * @param string $defaultValue
-     * @return multiple
+     * {@inheritdoc}
      */
     public function getPut(
         $name = null,
@@ -55,7 +41,7 @@ abstract class Request extends \Phalcon\Http\Request
         $noRecursive = null
     ) {
         // perform parent function
-        $request = parent::getPut($name, $filters, $defaultValue);
+        $request = parent::getPut($name, $filters, $defaultValue, $notAllowEmpty, $noRecursive);
 
         // special handling for array requests, for individual inputs return what is request
         if (is_array($request) and $this->defaultCaseFormat != false) {
@@ -89,8 +75,8 @@ abstract class Request extends \Phalcon\Http\Request
     /**
      * for a given array of values, convert cases to the defaultCaseFormat
      *
-     * @param array $request
-     * @return array
+     * @param array|object $request
+     * @return array|object
      */
     protected function convertCase($request)
     {

--- a/src/Result/Adapters/ActiveModel/Result.php
+++ b/src/Result/Adapters/ActiveModel/Result.php
@@ -1,6 +1,7 @@
 <?php
 namespace PhalconRest\Result\Adapters\ActiveModel;
 
+use Phalcon\Mvc\Model\Message;
 use PhalconRest\Exception\HTTPException;
 
 class Result extends \PhalconRest\Result\Result
@@ -13,66 +14,114 @@ class Result extends \PhalconRest\Result\Result
      */
     protected function formatJSON()
     {
-        $result = new \stdClass();
+        $result = new \stdClass;
 
         // this is used to ensure there is at least a blank array when requesting records
         if ($this->type !== false) {
             $result->{$this->type} = [];
         }
 
-        if ($this->outputMode != self::MODE_ERROR) {
-            switch ($this->outputMode) {
-                case self::MODE_SINGLE:
-                    if (count($this->data)) {
-                        $data = $this->data[0];
-                        $type = $data->getType();
-                        $result->$type = $data;
-                    }
-                    break;
-
-                case self::MODE_MULTIPLE:
-                    // push all data records into the result set
-                    foreach ($this->data as $data) {
-                        $type = $data->getType();
-                        if (!isset($result->$type)) {
-                            $result->$type = [];
-                        }
-                        array_push($result->$type, $data);
-                    }
-                    break;
-
-                case self::MODE_OTHER:
-                    // do nothing for this output mode
-                    break;
-
-                default:
-                    throw new HTTPException('Error generating output.  Cannot match output mode with data set.', 500, [
-                        'code' => '894684684646846816161'
-                    ]);
-            }
-
-            // push all includes into the result set. for the purpose of active model, they look just like data records
-            foreach ($this->included as $data) {
-                $type = $data->getType();
-                if (!isset($result->$type)) {
-                    $result->$type = [];
-                }
-                array_push($result->$type, $data);
-            }
-
-            // include plain non-namespaced data
-            foreach ($this->plain as $key => $value) {
-                $result->$key = $value;
-            }
+        if ($this->outputMode == self::MODE_ERROR) {
+            $this->formatFailure($result);
         } else {
-            $result->errors = $this->errors;
+            $this->formatSuccess($result);
         }
+
         // only include if it has valid data
         if ($this->meta) {
             $result->meta = $this->meta;
         }
 
         return $result;
+    }
+
+    protected function formatFailure($result)
+    {
+        $appConfig = $this->di->get('config')['application'];
+        $inflector = $this->di->get('inflector');
+
+        $result->errors = [];
+        foreach ($this->errors as $error) {
+            $details = [
+                'title' => $error->title,
+                'code' => $error->code,
+                'details' => $error->more
+            ];
+
+            if ($error->validationList) {
+                foreach ($error->validationList as $validation) {
+                    $field = $inflector->normalize($validation->getField(), $appConfig['propertyFormatTo']);
+                    $details[$field] = $validation->getMessage();
+                }
+            }
+
+            if ($appConfig['debugApp']) {
+                $meta = array_filter([ //clears up empty keys
+                    'developer_message' => $error->dev,
+                    'file' => $error->file,
+                    'line' => $error->line,
+                    'stack' => $error->stack,
+                    'context' => $error->context,
+                ]);
+
+                if ($meta) {
+                    $details['meta'] = $meta;
+                }
+            }
+
+            $result->errors[] = $details;
+        }
+    }
+
+    /**
+     * @param $result
+     * @throws HTTPException
+     */
+    protected function formatSuccess($result)
+    {
+        switch ($this->outputMode) {
+            case self::MODE_SINGLE:
+                if (count($this->data)) {
+                    $data = $this->data[0];
+                    $type = $data->getType();
+                    $result->$type = $data;
+                }
+                break;
+
+            case self::MODE_MULTIPLE:
+                // push all data records into the result set
+                foreach ($this->data as $data) {
+                    $type = $data->getType();
+                    if (!isset($result->$type)) {
+                        $result->$type = [];
+                    }
+                    array_push($result->$type, $data);
+                }
+                break;
+
+            case self::MODE_OTHER:
+                // do nothing for this output mode
+                break;
+
+            default:
+                throw new HTTPException('Error generating output.  Cannot match output mode with data set.', 500, [
+                    'code' => '894684684646846816161'
+                ]);
+        }
+
+        // push all includes into the result set. for the purpose of active model, they look just like data records
+        foreach ($this->included as $data) {
+            $type = $data->getType();
+            if (!isset($result->$type)) {
+                $result->$type = [];
+            }
+            array_push($result->$type, $data);
+        }
+
+        // include plain non-namespaced data
+        foreach ($this->plain as $key => $value) {
+            $result->$key = $value;
+        }
     }
 
 }

--- a/src/Result/Adapters/JsonApi/Result.php
+++ b/src/Result/Adapters/JsonApi/Result.php
@@ -35,7 +35,7 @@ class Result extends \PhalconRest\Result\Result
                 $result->included = $this->included;
             }
         } else {
-            // process expected error results here
+            //TODO: process expected error results here
             $result->errors = $this->errors;
         }
 

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -1,9 +1,9 @@
 <?php
 namespace PhalconRest\Result;
 
+use PhalconRest\Exception\ErrorStore;
 use \PhalconRest\Exception\HTTPException;
 use Phalcon\Mvc\Model\Relation as PhalconRelation;
-use PhalconRest\Result\Data;
 
 /**
  * The object used to store intermediate api results before they are sent to the client
@@ -66,7 +66,7 @@ abstract class Result extends \Phalcon\DI\Injectable
      * // 1 = hasOne 0 = belongsTo 2 = hasMany
      *
      * @throws HTTPException
-     * @param $relation
+     * @param \PhalconRest\Api\Relation|PhalconRelation $relation
      */
     public function registerRelationshipDefinitions($relation)
     {
@@ -119,12 +119,12 @@ abstract class Result extends \Phalcon\DI\Injectable
     /**
      * add an error store object to the Result payload
      *
-     * @param \PhalconRest\Exception\ErrorStore $Error
+     * @param ErrorStore $error
      */
-    public function addError(\PhalconRest\Exception\ErrorStore $Error)
+    public function addError(ErrorStore $error)
     {
         $this->outputMode = self::MODE_ERROR;
-        $this->errors[] = $Error;
+        $this->errors[] = $error;
     }
 
 
@@ -181,7 +181,7 @@ abstract class Result extends \Phalcon\DI\Injectable
      */
     public function addPlain($key, $value)
     {
-        $this->Plain[$key] = $value;
+        $this->plain[$key] = $value;
     }
 
 
@@ -265,7 +265,7 @@ abstract class Result extends \Phalcon\DI\Injectable
     {
         if ($key) {
             if (isset($this->plain[$key])) {
-                $this->plain[$key];
+                return $this->plain[$key];
             } else {
                 return null;
             }

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -19,16 +19,16 @@ abstract class Result extends \Phalcon\DI\Injectable
     /** a collection of individual data objects */
     protected $data = [];
 
-    /** meta data describing the request or data collected */
+    /** @var Data[] meta data describing the request or data collected */
     protected $meta = [];
 
-    /** store errors to be returned to the client */
+    /** @var ErrorStore[] Store errors to be returned to the client */
     protected $errors = [];
 
     /** store any simple non-namespaced data that is to be included in the output */
     protected $plain = [];
 
-    /** store a collection of data like items */
+    /** @var Data[] store a collection of data like items */
     protected $included = [];
 
     /** store the list of relationships for a "main" record type
@@ -43,7 +43,7 @@ abstract class Result extends \Phalcon\DI\Injectable
     // possible outputModes, useful for some adapter types
     const MODE_SINGLE = 'single';  // return a single result
     const MODE_MULTIPLE = 'multiple'; // return "n" results
-    const MODE_ERROR = 'error'; // indicate one or more errors occured
+    const MODE_ERROR = 'error'; // indicate one or more errors occurred
     const MODE_OTHER = 'other'; // return custom data of some type
 
     /**

--- a/src/Util/Inflector.php
+++ b/src/Util/Inflector.php
@@ -367,14 +367,13 @@ class Inflector
     /**
      * In-Place, recursive conversion of array keys in snake_Case to camelCase
      *
-     * @param array $snakeArray
-     *            Array with snake_keys
-     * @return no return value, array is edited in place
+     * @param array $snakeArray Array with snake_keys
+     * @return array
      */
     final public function arrayKeysToCamel(array $snakeArray)
     {
         // hold the array of new values
-        $camelArray = array();
+        $camelArray = [];
         foreach ($snakeArray as $key => $value) {
             // tricky recursive
             if (is_array($value)) {
@@ -383,32 +382,29 @@ class Inflector
             $camelArray[$this->camelize($key)] = $value;
             unset($snakeArray[$key]);
         }
-        unset($snakeArray);
         return $camelArray;
     }
 
     /**
      * In-Place, recursive conversion of stdClass keys in snake_Case to camelCase
      *
-     * @param stdClass $snakeObject
-     *            Object with snake_properties
-     * @return no return value, array is edited in place
+     * @param object $snakeObject Object with snake_properties
+     * @return object
      */
     final public function objectPropertiesToCamel($snakeObject)
     {
-        // hold the array of new values
+        // hold the object of new values
         $camelObject = new \stdClass();
         foreach ($snakeObject as $key => $value) {
             // tricky recursive for objects or arrays
             if (is_object($value)) {
-                $value = $this->objectKeysToCamel($value);
+                $value = $this->objectPropertiesToCamel($value);
             } elseif (is_array($value)) {
                 $value = $this->arrayKeysToCamel($value);
             }
             $camelObject->{$this->camelize($key)} = $value;
             unset($snakeObject[$key]);
         }
-        unset($snakeObject);
         return $camelObject;
     }
 
@@ -416,13 +412,12 @@ class Inflector
      * In-Place, recursive conversion of array keys in camelCase to snake_Case
      *
      * @param array $camelArray
-     *            Array with camelArray
      * @return array
      */
     final public function arrayKeysToSnake(array $camelArray)
     {
         // hold the array of new values
-        $snakeArray = array();
+        $snakeArray = [];
         foreach ($camelArray as $key => $value) {
             // tricky recursive
             if (is_array($value)) {
@@ -438,11 +433,10 @@ class Inflector
     /**
      * In-Place, recursive conversion of object properties in camelCase to snake_Case
      *
-     * @param stdClass $camelObject
-     *            Object with camelObject
+     * @param object $camelObject
      * @return object
      */
-    final public function objectPropertiesToSnake($camelObject, $parent_key = "root")
+    final public function objectPropertiesToSnake($camelObject, $parent_key = 'root')
     {
         // hold the array of new values
         $snakeObject = new \stdClass();
@@ -503,7 +497,6 @@ class Inflector
                 }
             }
         }
-        unset($camelObject);
         return $snakeObject;
     }
 }

--- a/src/bin/bootstrap/web.php
+++ b/src/bin/bootstrap/web.php
@@ -78,13 +78,11 @@ $app->after(function () use ($app) {
             $app->response->setStatusCode('200', 'OK');
             $app->response->send();
             return;
-            break;
 
         case 'DELETE': //FIXME: usually this is true, but not all DELETE requests would come without content
             $app->response->setStatusCode('204', 'No Content');
             $app->response->send();
             return;
-            break;
 
         case 'POST':
             //FIXME: not all POST requests actually create a new resource. 200 should be used otherwise


### PR DESCRIPTION
- mungeData is not mandatory anymore, as it's not always needed
- getJson() now is future-proof for nullable types, returning null instead of false in case of issues
- getPut() obeys it's parent signature
- plain[] handling was fixed
- a bunch of code style improvements