### PR TITLE
Maintenance mode, bunch of small fixes

### DIFF
--- a/src/API/Entity.php
+++ b/src/API/Entity.php
@@ -1170,12 +1170,15 @@ class Entity extends Injectable
      * watch $id to determine if update or insert
      * built to accommodate saving records w/ parent tables (hasOne)
      *
-     * @param mixed $formData the data submitted to the server
+     * @param array|object $formData the data submitted to the server
      * @param int $id the pkid of the record to be updated, otherwise null on inserts
      * @return int the PKID of the record in question
      */
     public function save($formData, $id = null)
     {
+        if (!is_object($formData)) {
+            $formData = (object)$formData;
+        }
         // check if inserting a new record and account for any parent records
         if (is_null($id)) {
             $this->saveMode = 'insert';
@@ -1245,10 +1248,10 @@ class Entity extends Injectable
      * along with loading client submitted data into each model
      *
      * @param BaseModel $model
-     * @param object $object
+     * @param object    $formData
      * @return bool|object $model
      */
-    public function loadParentModel(BaseModel $model, $object)
+    public function loadParentModel(BaseModel $model, $formData)
     {
         // invalid first param, return false though it won't do much good
         if ($model === false) {
@@ -1266,11 +1269,11 @@ class Entity extends Injectable
                 $primaryKey = $model->getPrimaryKeyName();
                 $finalModel = $parentModel::findFirst($model->$primaryKey);
             } else {
-                $finalModel = $this->loadParentModel($parentModel, $object);
+                $finalModel = $this->loadParentModel($parentModel, $formData);
             }
 
             // don't forget to load the child model values and mount into parent model
-            $childModel = $this->loadModelValues($model, $object);
+            $childModel = $this->loadModelValues($model, $formData);
             $childModelName = $model->getModelName();
             $finalModel->$childModelName = $childModel;
         } else {
@@ -1278,7 +1281,7 @@ class Entity extends Injectable
         }
 
         // run object data through the model
-        return $this->loadModelValues($finalModel, $object);
+        return $this->loadModelValues($finalModel, $formData);
     }
 
     /**

--- a/src/Exception/HTTPException.php
+++ b/src/Exception/HTTPException.php
@@ -42,6 +42,7 @@ class HTTPException extends \Exception
         // store general error data
         $this->errorStore = new ErrorStore($errorList);
         $this->errorStore->title = $title;
+        $this->errorStore->code = $localCode;
 
         $this->di = \Phalcon\DI::getDefault();
     }

--- a/src/Exception/HTTPException.php
+++ b/src/Exception/HTTPException.php
@@ -35,7 +35,7 @@ class HTTPException extends \Exception
     public function __construct($title, $code, $errorList = [], \Throwable $previous = null)
     {
         //attaching local code to Exception message in case it's catch somewhere else
-        $localCode = $errorList['code'] ?? $code;
+        $localCode = isset($errorList['code'])? $errorList['code'] . '/' . $code : $code;
 
         parent::__construct("[$localCode] $title", $code, $previous);
 
@@ -44,12 +44,11 @@ class HTTPException extends \Exception
         $this->errorStore->title = $title;
         $this->errorStore->code = $localCode;
 
-        $this->di = \Phalcon\DI::getDefault();
+        $this->di = \Phalcon\Di::getDefault();
     }
 
     /**
      * Calls out {@link Output::sendError()} with the appropriate values.
-     * @return boolean
      */
     public function send()
     {
@@ -59,7 +58,7 @@ class HTTPException extends \Exception
         //push errorStore into $result object for proper handling
         $result = $this->di->get('result', []);
         $result->addError($this->errorStore);
-        return $output->send($result);
+        $output->send($result);
     }
 
     /**

--- a/src/Result/Adapters/ActiveModel/Data.php
+++ b/src/Result/Adapters/ActiveModel/Data.php
@@ -12,7 +12,7 @@ class Data extends \PhalconRest\Result\Data
      *
      * @return array
      */
-    public function JsonSerialize()
+    public function jsonSerialize()
     {
         // if formatting is requested, well then format baby!
         $config = $this->di->get('config');
@@ -33,7 +33,8 @@ class Data extends \PhalconRest\Result\Data
 
         if ($this->relationships) {
             foreach ($this->relationships as $name => $keys) {
-                $result[$name] = array_keys($keys);
+                $ids = array_keys($keys);
+                $result[$name] = (sizeof($ids) == 1)? current($ids) : $ids;
             }
             // $result['relationships'] = $this->relationships;
         }

--- a/src/Result/Adapters/JsonApi/Data.php
+++ b/src/Result/Adapters/JsonApi/Data.php
@@ -9,7 +9,7 @@ class Data extends \PhalconRest\Result\Data
      *
      * @return array
      */
-    public function JsonSerialize()
+    public function jsonSerialize()
     {
         // if formatting is requested, well then format baby!
         $config = $this->di->get('config');

--- a/src/Result/Data.php
+++ b/src/Result/Data.php
@@ -11,14 +11,11 @@ use Phalcon\Mvc\Model\Relation as PhalconRelation;
 abstract class Data extends \Phalcon\DI\Injectable implements \JsonSerializable
 {
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $id;
 
     /**
-     * this maps to a model or table name?
-     *
+     * Table name (snake_cased model name) related to this data piece
      * @var string
      */
     protected $type;
@@ -36,7 +33,7 @@ abstract class Data extends \Phalcon\DI\Injectable implements \JsonSerializable
      * or
      * $relationships[TABLENAME] = [ [ID=>#, TYPE=>''] ];
      *
-     * @var array
+     * @var array|array[]
      */
     public $relationships;
 
@@ -50,7 +47,7 @@ abstract class Data extends \Phalcon\DI\Injectable implements \JsonSerializable
      */
     public function __construct($id, $type, array $attributes = [], array $relationships = [])
     {
-        $di = \Phalcon\DI::getDefault();
+        $di = \Phalcon\Di::getDefault();
         $this->setDI($di);
 
         //parse supplied data array and populate object
@@ -115,7 +112,7 @@ abstract class Data extends \Phalcon\DI\Injectable implements \JsonSerializable
      * simple getters and setters
      * @return int
      */
-    public function getId()
+    public function getId():int
     {
         return $this->id;
     }

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -16,7 +16,7 @@ abstract class Result extends \Phalcon\DI\Injectable
      * but might be used by adapters for their own purposes */
     protected $type = false;
 
-    /** a collection of individual data objects */
+    /** @var Data[] a collection of individual data objects */
     protected $data = [];
 
     /** @var Data[] meta data describing the request or data collected */

--- a/src/bin/base.php
+++ b/src/bin/base.php
@@ -77,7 +77,7 @@ if (!function_exists('array_deep_key_exists')) {
     }
 }
 
-if (!function_exists('array_deep_key_exists')) {
+if (!function_exists('array_flatten')) {
     /**
      * Flattens all entries of a matrix into a single, long array of values.
      * @param array $matrix A multi-dimensional array
@@ -86,7 +86,7 @@ if (!function_exists('array_deep_key_exists')) {
     function array_flatten(array $matrix):array
     {
         $result = [];
-        array_walk_recursive($matrix, function ($v) use ($result) {
+        array_walk_recursive($matrix, function ($v) use (&$result) {
             $result[] = $v;
         });
         return $result;

--- a/src/bin/bootstrap/cli.php
+++ b/src/bin/bootstrap/cli.php
@@ -5,6 +5,10 @@ use Phalcon\CLI\Console as ConsoleApp;
 $console = new ConsoleApp();
 $console->setDI($di);
 
+if ($config['application']['maintenance']) {
+    die('Server is down for maintenance.' . PHP_EOL);
+}
+
 /**
  * Process the console arguments
  */

--- a/src/bin/bootstrap/web.php
+++ b/src/bin/bootstrap/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use PhalconRest\Exception\HTTPException;
+use PhalconRest\Result\Result;
 
 /**
  * Our application is a Micro application, so we must explicitly define all the routes.
@@ -49,15 +50,13 @@ $app->get('/', function () use ($app, $di) {
         'OPTIONS' => []
     ];
     foreach ($routes as $route) {
-        $method = $route->getHttpMethods();
+        $method = $route->getHttpMethods() ?? 'any';
         $routeDefinitions[$method][] = $route->getPattern();
     }
+    /** @var Result $result */
     $result = $di->get('result', []);
     $result->outputMode = 'other';
-
-    foreach ($routeDefinitions as $key => $value) {
-        $result->setPlain($key, $value);
-    }
+    $result->addPlains($routeDefinitions);
     return $result;
 });
 

--- a/src/bin/config.php
+++ b/src/bin/config.php
@@ -8,6 +8,9 @@ require_once API_PATH . 'bin/base.php';
 // you can override these values with an environmental specific file in app/config/FILE.php
 $config = [
     'application' => [
+        // routes all requests to a 503 - useful during deploys. Disable after deploy is done
+        'maintenance' => false,
+
         // the path to the main directory holding the application
         'appDir' => APPLICATION_PATH,
         // path values to commonly expected api files
@@ -17,7 +20,7 @@ $config = [
         "responsesDir" => APPLICATION_PATH . 'responses/',
         "librariesDir" => APPLICATION_PATH . 'libraries/',
 
-        // is this used?
+        //TODO: is this used?
         "exceptionsDir" => APPLICATION_PATH . 'exceptions/',
 
         // base string after FQDN.../api/v1 or some such

--- a/src/bin/loader.php
+++ b/src/bin/loader.php
@@ -1,7 +1,6 @@
 <?php
 
 use Phalcon\Loader;
-use PhalconRest\Libraries\Formatters;
 
 // read in config values from API and currently defined environment
 require_once API_PATH . 'bin/config.php';
@@ -17,16 +16,16 @@ require_once API_PATH . 'bin/config.php';
  * This function allows us to assign namespaces to alternative folders.
  * It also puts the classes into the PSR-0 autoLoader.
  */
-$loader = new Loader();
+$loader = new Loader;
 
-$nameSpaces = array(
+$nameSpaces = [
     'PhalconRest\Models' => $config['application']['modelsDir'],
     'PhalconRest\Entities' => $config['application']['entitiesDir'],
     'PhalconRest\Controllers' => $config['application']['controllersDir'],
     'PhalconRest\Exceptions' => $config['application']['exceptionsDir'],
     'PhalconRest\Libraries' => $config['application']['librariesDir'],
     'PhalconRest\Responses' => $config['application']['responsesDir']
-);
+];
 
 // load Composer Namespaces
 $map = require COMPOSER_PATH . 'composer/autoload_namespaces.php';

--- a/src/bin/maintenanceRoute.php
+++ b/src/bin/maintenanceRoute.php
@@ -1,0 +1,10 @@
+<?php
+$catchAll = new \Phalcon\Mvc\Micro\Collection;
+$catchAll->setHandler(new class {
+    function maintenance() {
+        throw new \PhalconRest\Exception\HTTPException('Maintenance mode', 503, ['more' => 'Server is down for maintenance, and will be back shortly.']);
+    }
+});
+
+$catchAll->map('/:params', 'maintenance'); //:params is a "catch-the-rest" regex
+return [$catchAll];

--- a/src/bin/services.php
+++ b/src/bin/services.php
@@ -173,11 +173,12 @@ $di->setShared('requestBody', function () {
     // JSON body could not be parsed, throw exception
     if ($in === null) {
         throw new HTTPException('There was a problem understanding the data sent to the server by the application.',
-            409, array(
+            409, [
                 'dev' => 'The JSON body sent to the server was unable to be parsed.',
                 'code' => '5',
-                'more' => ''
-            ));
+                'more' => json_last_error().' - '.json_last_error_msg()
+            ]);
     }
+
     return $in;
 });


### PR DESCRIPTION
7985278 (Igor Santos, 18 seconds ago)
    Displaying JSON errors on invalid request bodies

f865773 (Igor Santos, 46 seconds ago)
    Adding a Maintenance Mode setting on config.application.maintenance -
    returns 503 on any request, and dies early on CLI calls

 1698bab (Igor Santos, 11 minutes ago)
    Forcing HTTP Exceptions to display both their codes so that's searchable
    from Sentry

 2932c88 (Igor Santos, 2 days ago)
    Adding the correct HTTP code to its ErrorStore object

 7d847a6 (Jim, 5 weeks ago)
    bug fix that surfaced on JSON API

 c254809 (Igor Santos, 11 days ago)
    Enabling usage of array data in model save() calls as well

 5c1f081 (Igor Santos, 3 weeks ago)
    Single relationshop results are now set as simple values instead of a
    one-entry array (that could override simple fields from the resultset). IDs
    are also integers whenever possible